### PR TITLE
v1.3.16

### DIFF
--- a/core/php/.htaccess
+++ b/core/php/.htaccess
@@ -1,2 +1,0 @@
-Order allow,deny
-Deny from all

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "tvremote",
 	"name": "TV Remote",
-	"pluginVersion": "1.3.15",
+	"pluginVersion": "1.3.16",
 	"description": {
 		"fr_FR": "Plugin pour contrôler les équipements Android de type Télévision (Sony, Nvidia Shield, Freebox TV, etc...) via le service de télécommande Google (TVRemote) ou via ADB. Il permet de contrôler les différentes fonctions de sa télévision (power, volume, entrées HDMI, lancement d'applications, chaînes TV, navigation dans l'interface, etc...)",
 		"en_US": "Plugin to control Android TV devices (Sony, Nvidia Shield, Freebox TV, etc...) via Google remote control service (TVRemote) or via ADB. It allows you to control various functions of your TV (power, volume, HDMI inputs, launching applications, TV channels, navigating the interface, etc...)",

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -122,21 +122,27 @@ function tvremote_update() {
             // Accepte fichiers ET répertoires (rm -rf) — ajouter ici les chemins à supprimer à chaque mise à jour
             $pluginDir . '/core/php/.htaccess',
         );
+        $cleanupRemoved = 0;
+        $cleanupErrors = 0;
         foreach ($pathsToRemove as $path) {
-            log::add('tvremote', 'debug', '[CLEANUP] Vérification du chemin : ' . $path);
             if (file_exists($path)) {
                 $output = array();
                 $returnVar = 0;
                 exec('rm -rf ' . escapeshellarg($path) . ' 2>&1', $output, $returnVar);
                 if ($returnVar !== 0) {
+                    $cleanupErrors++;
                     log::add('tvremote', 'warning', '[CLEANUP_KO] Echec suppression "' . $path . '" (Code: ' . $returnVar . ') : ' . implode(' ', $output));
                 } else {
+                    $cleanupRemoved++;
                     log::add('tvremote', 'info', '[CLEANUP_OK] Chemin supprimé : ' . $path);
                 }
-            } else {
-                log::add('tvremote', 'debug', '[CLEANUP_NA] Chemin non trouvé, aucune action : ' . $path);
             }
         }
+        $cleanupSummary = count($pathsToRemove) . ' chemin(s) vérifié(s), ' . $cleanupRemoved . ' supprimé(s)';
+        if ($cleanupErrors > 0) {
+            $cleanupSummary .= ', ' . $cleanupErrors . ' erreur(s)';
+        }
+        log::add('tvremote', 'debug', '[CLEANUP] ' . $cleanupSummary);
     } catch (Exception $e) {
         log::add('tvremote', 'warning', '[CLEANUP_KO] Erreur lors du nettoyage : ' . $e->getMessage());
     }

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -114,6 +114,32 @@ function tvremote_update() {
             message::add('tvremote', __('Une erreur est survenue à la mise à jour automatique des dépendances. Vérifiez les logs et relancez les dépendances manuellement', __FILE__));
         }
     }
+
+    // Nettoyage des anciens fichiers et répertoires obsolètes
+    $pluginDir = dirname(__DIR__);
+    try {
+        $pathsToRemove = array(
+            // Accepte fichiers ET répertoires (rm -rf) — ajouter ici les chemins à supprimer à chaque mise à jour
+            $pluginDir . '/core/php/.htaccess',
+        );
+        foreach ($pathsToRemove as $path) {
+            log::add('tvremote', 'debug', '[CLEANUP] Vérification du chemin : ' . $path);
+            if (file_exists($path)) {
+                $output = array();
+                $returnVar = 0;
+                exec('rm -rf ' . escapeshellarg($path) . ' 2>&1', $output, $returnVar);
+                if ($returnVar !== 0) {
+                    log::add('tvremote', 'warning', '[CLEANUP_KO] Echec suppression "' . $path . '" (Code: ' . $returnVar . ') : ' . implode(' ', $output));
+                } else {
+                    log::add('tvremote', 'info', '[CLEANUP_OK] Chemin supprimé : ' . $path);
+                }
+            } else {
+                log::add('tvremote', 'debug', '[CLEANUP_NA] Chemin non trouvé, aucune action : ' . $path);
+            }
+        }
+    } catch (Exception $e) {
+        log::add('tvremote', 'warning', '[CLEANUP_KO] Erreur lors du nettoyage : ' . $e->getMessage());
+    }
 }
 
 // Fonction exécutée automatiquement après la suppression du plugin


### PR DESCRIPTION
This pull request introduces a cleanup mechanism to the plugin update process, ensuring obsolete files are removed during updates. It also updates the plugin version to reflect these changes.

**Plugin maintenance and cleanup:**

* Added a cleanup step in the `tvremote_update` function to automatically remove obsolete files (such as `core/php/.htaccess`) during plugin updates, with logging for success and error cases.
* Removed the legacy `.htaccess` file from `core/php` as part of the cleanup process.

**Versioning:**

* Bumped the plugin version from `1.3.15` to `1.3.16` in `plugin_info/info.json` to reflect the new changes.