### PR TITLE
v1.3.17

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-ignore = W,BLK,E203,E302,E305,E402,E501,E117,E101

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe",
     "cSpell.words": [
         "adbkey",
         "adbkeyfilepath",
@@ -91,5 +92,12 @@
         "youtube",
         "zconf",
         "zeroconf"
+    ],
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
     ]
 }

--- a/core/class/tvremote.class.php
+++ b/core/class/tvremote.class.php
@@ -490,7 +490,8 @@ class tvremote extends eqLogic {
                 'mac' => $this->getLogicalId(),
                 'host' => $this->getConfiguration('host'),
                 'port' => $this->getConfiguration('port'),
-                'friendly_name' => $this->getConfiguration('friendly_name')
+                'friendly_name' => $this->getConfiguration('friendly_name'),
+                'enable_ime' => $this->getConfiguration('enable_ime', 1)
             );
             self::sendToDaemon($value);
         }

--- a/core/class/tvremote.class.php
+++ b/core/class/tvremote.class.php
@@ -485,6 +485,11 @@ class tvremote extends eqLogic {
     }
 
     public function enableTVRemoteToDaemon() {
+        $deamon_info = self::deamon_info();
+        if ($deamon_info['state'] !== 'ok') {
+            log::add('tvremote', 'debug', '[enableTVRemoteToDaemon] Démon non démarré, envoi ignoré pour ' . $this->getLogicalId());
+            return;
+        }
         if ($this->getLogicalId() !== '') {
             $value = array(
                 'cmd' => 'addtvremote',
@@ -499,6 +504,11 @@ class tvremote extends eqLogic {
     }
 
     public function enableADBToDaemon() {
+        $deamon_info = self::deamon_info();
+        if ($deamon_info['state'] !== 'ok') {
+            log::add('tvremote', 'debug', '[enableADBToDaemon] Démon non démarré, envoi ignoré pour ' . $this->getLogicalId());
+            return;
+        }
         if ($this->getLogicalId() !== '') {
             $value_adb = array(
                 'cmd' => 'addtvremote_adb',
@@ -514,6 +524,11 @@ class tvremote extends eqLogic {
     }
 
     public function disableTVRemoteToDaemon() {
+        $deamon_info = self::deamon_info();
+        if ($deamon_info['state'] !== 'ok') {
+            log::add('tvremote', 'debug', '[disableTVRemoteToDaemon] Démon non démarré, envoi ignoré pour ' . $this->getLogicalId());
+            return;
+        }
         if ($this->getLogicalId() !== '') {
             $value = array(
                 'cmd' => 'removetvremote',
@@ -527,6 +542,11 @@ class tvremote extends eqLogic {
     }
 
     public function disableADBToDaemon() {
+        $deamon_info = self::deamon_info();
+        if ($deamon_info['state'] !== 'ok') {
+            log::add('tvremote', 'debug', '[disableADBToDaemon] Démon non démarré, envoi ignoré pour ' . $this->getLogicalId());
+            return;
+        }
         if ($this->getLogicalId() !== '') {
             $value_adb = array(
                 'cmd' => 'removetvremote_adb',

--- a/core/class/tvremote.class.php
+++ b/core/class/tvremote.class.php
@@ -423,6 +423,7 @@ class tvremote extends eqLogic {
             $eqLogic->setConfiguration('host', $_data['host']);
             $eqLogic->setConfiguration('port', $_data['port']);
             $eqLogic->setConfiguration('lastscan', $_data['lastscan']);
+            $eqLogic->setConfiguration('enable_ime', 1);
             $eqLogic->save();
 
             event::add('tvremote::scanResult', array(

--- a/desktop/php/tvremote.php
+++ b/desktop/php/tvremote.php
@@ -206,7 +206,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="form-group">
                                 <label class="col-sm-4 control-label">{{Clavier Virtuel (IME)}}
                                     <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
-                                    <sup><i class="fas fa-question-circle tooltips" title="{{Coché (par défaut) : Permet de récupérer la « Current App » (Nom de l'application en cours) et d'envoyer du texte via le clavier virtuel.<br>Décoché : A utiliser si votre TV affiche « Utiliser le clavier sur votre smartphone » au lieu du clavier intégré.}}"></i></sup>
+                                    <sup><i class="fas fa-question-circle tooltips" title="{{Activer (par défaut) : Permet l'usage de la commande « Current App » (Application en cours) et d'envoyer du texte.<br>Désactiver : Si votre TV affiche « Utiliser le clavier sur votre smartphone » au lieu du clavier intégré.}}"></i></sup>
                                 </label>
                                 <div class="col-sm-6">
                                     <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="enable_ime" checked />{{Activer}}</label>

--- a/desktop/php/tvremote.php
+++ b/desktop/php/tvremote.php
@@ -153,7 +153,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                     <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="isVisible" checked>{{Visible}}</label>
                                 </div>
                             </div>
-                            <legend><i class="fas fa-cogs"></i> {{Paramètres du TVRemote}}</legend>
+                            <legend><i class="fas fa-tv"></i> {{Informations}}</legend>
                             <div class="form-group">
                                 <label class="col-sm-4 control-label">{{Adresse MAC}}</label>
                                 <div class="col-sm-6">
@@ -200,6 +200,16 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 <label class="col-sm-4 control-label">{{Dernier Scan}}</label>
                                 <div class="col-sm-6">
                                     <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="lastscan" readonly />
+                                </div>
+                            </div>
+                            <legend><i class="fas fa-sliders-h"></i> {{Compatibilité}}</legend>
+                            <div class="form-group">
+                                <label class="col-sm-4 control-label">{{Clavier Virtuel (IME)}}
+                                    <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
+                                    <sup><i class="fas fa-question-circle tooltips" title="{{Coché : le clavier virtuel de la télécommande est activé (nécessaire pour la remontée de l'application active).<br>Décoché : désactive le clavier virtuel, à utiliser si votre TV affiche systématiquement « Utiliser le clavier sur votre smartphone » au lieu du clavier GBoard.}}"></i></sup>
+                                </label>
+                                <div class="col-sm-6">
+                                    <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="enable_ime" checked />{{Activer}}</label>
                                 </div>
                             </div>
                         </div>

--- a/desktop/php/tvremote.php
+++ b/desktop/php/tvremote.php
@@ -202,11 +202,11 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                     <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="lastscan" readonly />
                                 </div>
                             </div>
-                            <legend><i class="fas fa-sliders-h"></i> {{Compatibilité}}</legend>
+                            <legend><i class="fas fa-sliders-h"></i> {{Paramètres avancés}}</legend>
                             <div class="form-group">
                                 <label class="col-sm-4 control-label">{{Clavier Virtuel (IME)}}
                                     <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
-                                    <sup><i class="fas fa-question-circle tooltips" title="{{Coché : le clavier virtuel de la télécommande est activé (nécessaire pour la remontée de l'application active).<br>Décoché : désactive le clavier virtuel, à utiliser si votre TV affiche systématiquement « Utiliser le clavier sur votre smartphone » au lieu du clavier GBoard.}}"></i></sup>
+                                    <sup><i class="fas fa-question-circle tooltips" title="{{Coché (par défaut) : Permet de récupérer la « Current App » (Nom de l'application en cours) et d'envoyer du texte via le clavier virtuel.<br>Décoché : A utiliser si votre TV affiche « Utiliser le clavier sur votre smartphone » au lieu du clavier intégré.}}"></i></sup>
                                 </label>
                                 <div class="col-sm-6">
                                     <label class="checkbox-inline"><input type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="enable_ime" checked />{{Activer}}</label>

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "tvremote",
 	"name": "TV Remote",
-	"pluginVersion": "1.3.16",
+	"pluginVersion": "1.3.17",
 	"description": {
 		"fr_FR": "Plugin pour contrôler les équipements Android de type Télévision (Sony, Nvidia Shield, Freebox TV, etc...) via le service de télécommande Google (TVRemote) ou via ADB. Il permet de contrôler les différentes fonctions de sa télévision (power, volume, entrées HDMI, lancement d'applications, chaînes TV, navigation dans l'interface, etc...)",
 		"en_US": "Plugin to control Android TV devices (Sony, Nvidia Shield, Freebox TV, etc...) via Google remote control service (TVRemote) or via ADB. It allows you to control various functions of your TV (power, volume, HDMI inputs, launching applications, TV channels, navigating the interface, etc...)",

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -115,6 +115,14 @@ function tvremote_update() {
         }
     }
 
+    // Migration v1.3.17 : initialisation de enable_ime pour les équipements existants
+    foreach (eqLogic::byType('tvremote') as $_eqLogic) {
+        if ($_eqLogic->getConfiguration('enable_ime', '') === '') {
+            $_eqLogic->setConfiguration('enable_ime', 1);
+            $_eqLogic->save();
+        }
+    }
+
     // Nettoyage des anciens fichiers et répertoires obsolètes
     $pluginDir = dirname(__DIR__);
     try {

--- a/resources/tvremoted/tvremoted.py
+++ b/resources/tvremoted/tvremoted.py
@@ -47,12 +47,13 @@ except ImportError as e:
 class EQRemote(object):
     """This is the Remote Device class"""
 
-    def __init__(self, _mac, _host, _config: Config, _jeedom_publisher) -> None:
+    def __init__(self, _mac, _host, _config: Config, _jeedom_publisher, _enable_ime: bool = True) -> None:
         # Standard Init of class
         self._config = _config
         self._remote = None
         self._macAddr = _mac
         self._host = _host
+        self._enable_ime = _enable_ime
         self._logger = logging.getLogger(__name__)
         self._jeedom_publisher = _jeedom_publisher
         self._loop = asyncio.get_running_loop()
@@ -79,7 +80,7 @@ class EQRemote(object):
         try:
             self._logger.debug("[EQRemote][MAIN][%s] Starting Main for Host :: %s", self._macAddr, self._host)
             
-            self._remote = AndroidTVRemote(self._config.client_name, self._config.cert_file, self._config.key_file, self._host)
+            self._remote = AndroidTVRemote(self._config.client_name, self._config.cert_file, self._config.key_file, self._host, enable_ime=self._enable_ime)
             
             if self._remote is None:
                 self._logger.error("[EQRemote][Remote] Object Creation Failed :: Object is None !")
@@ -983,7 +984,9 @@ class TVRemoted:
                         # Create new device
                         self._config.remote_mac.append(message['mac'])
                         self._logger.debug('[DAEMON][SOCKET] Add TVRemote (AndroidTVRemote2) to Remote MAC :: %s', str(self._config.remote_mac))
-                        device = EQRemote(message['mac'], message['host'], self._config, self._jeedom_publisher)
+                        _enable_ime = int(message.get('enable_ime', 1)) != 0
+                        self._logger.debug('[DAEMON][SOCKET] TVRemote %s (%s) :: IME (virtual keyboard) %s', message['friendly_name'], message['mac'], 'enabled' if _enable_ime else 'disabled')
+                        device = EQRemote(message['mac'], message['host'], self._config, self._jeedom_publisher, _enable_ime)
                         self._config.remote_devices[message['mac']] = device
                         # Launch main loop as async task (non-blocking)
                         device._main_task = asyncio.create_task(device.main())

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,18 @@
+target-version = "py312"
+
+[lint]
+# F = pyflakes (imports inutilisés, variables indéfinies)
+# E = pycodestyle errors (W exclu — non sélectionné, BLK sans équivalent ruff)
+select = ["E", "F"]
+ignore = [
+    "E101",  # indentation contains mixed spaces and tabs
+    "E117",  # over-indented
+    "E203",  # whitespace before ':'
+    "E302",  # expected 2 blank lines
+    "E305",  # expected 2 blank lines after class or function definition
+    "E402",  # module level import not at top of file
+    "E501",  # line too long
+]
+
+[lint.per-file-ignores]
+"__init__.py" = ["F401"]  # imports non utilisés normaux dans les __init__


### PR DESCRIPTION
This pull request introduces a new "Virtual Keyboard (IME)" configuration option for TV Remote devices, improves robustness when communicating with the daemon, and updates development environment settings and linting configuration. The changes ensure that the IME setting is properly initialized, exposed in the UI, and passed through the entire stack to the Python daemon. Additionally, the plugin version is incremented and development tooling is updated.

**TV Remote IME (Virtual Keyboard) Feature:**

* Added a new `enable_ime` configuration option for TV Remote devices, defaulting to enabled. This setting is now initialized for existing devices during upgrade and included in device creation and updates. (`core/class/tvremote.class.php`, `plugin_info/install.php`, `public static function createAndUpdTVRemoteFromScan`, `plugin_info/info.json`, [[1]](diffhunk://#diff-baae8b747340dcbf37887831f80949a6fa1798c82afbb49188e281d6b3590403R426) [[2]](diffhunk://#diff-d29ad66623b8d1c93164e29ccae746ec492d78c2a5f7f10a2eb8b6ab450cb292R118-R125) [[3]](diffhunk://#diff-73fca01855a04cfd1363d72519ecb7f9a94f7511bcf777ffdcb78c3eb26c1f85L4-R4)
* Updated the equipment UI to allow users to enable or disable the IME feature, with explanatory tooltips and warnings about daemon restarts. (`desktop/php/tvremote.php`, [desktop/php/tvremote.phpR205-R214](diffhunk://#diff-755be4aa45edc3e0e400afcc23e14214f70e92eaa6a123a81e7380ee8d89ea8eR205-R214))
* Modified the Python daemon to accept and use the `enable_ime` parameter when creating and managing remote devices, ensuring the IME setting is respected at runtime. (`resources/tvremoted/tvremoted.py`, [[1]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L50-R56) [[2]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L82-R83) [[3]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L986-R989)

**Daemon Communication Robustness:**

* Added checks in all methods that communicate with the daemon to ensure it is running before sending commands, logging and skipping actions if the daemon is not active. (`core/class/tvremote.class.php`, [[1]](diffhunk://#diff-baae8b747340dcbf37887831f80949a6fa1798c82afbb49188e281d6b3590403R488-R511) [[2]](diffhunk://#diff-baae8b747340dcbf37887831f80949a6fa1798c82afbb49188e281d6b3590403R527-R531) [[3]](diffhunk://#diff-baae8b747340dcbf37887831f80949a6fa1798c82afbb49188e281d6b3590403R545-R549)

**UI and Documentation Updates:**

* Reorganized the equipment UI sections, renaming and separating "Informations" and "Paramètres avancés" for clarity. (`desktop/php/tvremote.php`, [[1]](diffhunk://#diff-755be4aa45edc3e0e400afcc23e14214f70e92eaa6a123a81e7380ee8d89ea8eL156-R156) [[2]](diffhunk://#diff-755be4aa45edc3e0e400afcc23e14214f70e92eaa6a123a81e7380ee8d89ea8eR205-R214)

**Development Environment and Linting:**

* Updated VSCode settings to specify the Python interpreter and project environment, and added a `ruff.toml` configuration for Python linting, replacing the previous `.flake8` file. (`.vscode/settings.json`, [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R2) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R95-R101); `ruff.toml`, [[3]](diffhunk://#diff-26f436cb29eecc7bb4f9066747b43df8da81ac808955ce95c109f5d7aa778989R1-R18); `.flake8`, [[4]](diffhunk://#diff-6951dbb399883798a226c1fb496fdb4183b1ab48865e75eddecf6ceb6cf46442L1-L2)

**Versioning:**

* Bumped the plugin version to `1.3.17` to reflect these changes. (`plugin_info/info.json`, [plugin_info/info.jsonL4-R4](diffhunk://#diff-73fca01855a04cfd1363d72519ecb7f9a94f7511bcf777ffdcb78c3eb26c1f85L4-R4))