### PR TITLE
Bump plugin version and aiohttp dependency

### DIFF
--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "tvremote",
 	"name": "TV Remote",
-	"pluginVersion": "1.3.20",
+	"pluginVersion": "1.3.21",
 	"description": {
 		"fr_FR": "Plugin pour contrôler les équipements Android de type Télévision (Sony, Nvidia Shield, Freebox TV, etc...) via le service de télécommande Google (TVRemote) ou via ADB. Il permet de contrôler les différentes fonctions de sa télévision (power, volume, entrées HDMI, lancement d'applications, chaînes TV, navigation dans l'interface, etc...)",
 		"en_US": "Plugin to control Android TV devices (Sony, Nvidia Shield, Freebox TV, etc...) via Google remote control service (TVRemote) or via ADB. It allows you to control various functions of your TV (power, volume, HDMI inputs, launching applications, TV channels, navigating the interface, etc...)",

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,5 +1,5 @@
 zeroconf==0.149.16
-aiohttp==3.14.0
+aiohttp==3.14.1
 androidtvremote2==0.3.1
 adb-shell[async]==0.4.4
 rsa==4.9.1


### PR DESCRIPTION
Update plugin version to 1.3.21 and bump aiohttp from 3.14.0 to 3.14.1 in resources/requirements.txt. Changes applied to plugin_info/info.json and resources/requirements.txt to reflect a new release and include the dependency patch update.