### PR TITLE
Use --no-cache-dir for pip installs

### DIFF
--- a/resources/install_apt.sh
+++ b/resources/install_apt.sh
@@ -223,10 +223,10 @@ echo 70 > ${PROGRESS_FILE}
 log "*****************************"
 log "* Install Python3 libraries *"
 log "*****************************"
-${VENV_DIR}/bin/python3 -m pip install --upgrade pip wheel | log
+${VENV_DIR}/bin/python3 -m pip install --no-cache-dir --upgrade pip wheel | log
 log "** Install Pip / Wheel :: Done **"
 echo 75 > ${PROGRESS_FILE}
-${VENV_DIR}/bin/python3 -m pip install -r ${REQUIREMENTS_FILE} | log
+${VENV_DIR}/bin/python3 -m pip install --no-cache-dir -r ${REQUIREMENTS_FILE} | log
 log "** Install Python3 libraries :: Done **"
 echo 95 > ${PROGRESS_FILE}
 log "****************************"


### PR DESCRIPTION
Add the --no-cache-dir flag to pip install commands in resources/install_apt.sh (both the pip/wheel upgrade and the requirements installation) to avoid pip caching packages during automated installs. This reduces disk usage and prevents potential stale-cache issues in constrained or ephemeral environments.