### PR TITLE
Use --no-cache-dir for pip installs

### DIFF
--- a/resources/install_apt.sh
+++ b/resources/install_apt.sh
@@ -223,10 +223,10 @@ echo 70 > ${PROGRESS_FILE}
 log "*****************************"
 log "* Install Python3 libraries *"
 log "*****************************"
-${VENV_DIR}/bin/python3 -m pip install --upgrade pip wheel | log
+${VENV_DIR}/bin/python3 -m pip install --no-cache-dir --upgrade pip wheel | log
 log "** Install Pip / Wheel :: Done **"
 echo 75 > ${PROGRESS_FILE}
-${VENV_DIR}/bin/python3 -m pip install -r ${REQUIREMENTS_FILE} | log
+${VENV_DIR}/bin/python3 -m pip install --no-cache-dir -r ${REQUIREMENTS_FILE} | log
 log "** Install Python3 libraries :: Done **"
 echo 95 > ${PROGRESS_FILE}
 log "****************************"


### PR DESCRIPTION
This pull request makes a minor improvement to the Python package installation process in the `resources/install_apt.sh` script by ensuring that pip does not use the cache when installing or upgrading packages. This can help prevent issues related to stale or corrupted cached packages.

- Installation process improvement:
  * Added the `--no-cache-dir` option to all `pip install` commands to disable pip's package cache during installation and upgrades.