### PR TITLE
Improve Python deps checks and logging

### DIFF
--- a/core/class/tvremote.class.php
+++ b/core/class/tvremote.class.php
@@ -77,27 +77,27 @@ class tvremote extends eqLogic {
         } else {
             if (exec(system::getCmdSudo() . system::get('cmd_check') . '-Ec "python3\-requests|python3\-setuptools|python3\-dev|python3\-venv"') < 4) {
                 $return['state'] = 'nok';
-                log::add('tvremote', 'debug', '[Python-Dep] System packages missing (python3-requests, python3-setuptools, python3-dev, or python3-venv)');
+                log::add(__CLASS__, 'debug', '[Python-Dep] System packages missing (python3-requests, python3-setuptools, python3-dev, or python3-venv)');
             } elseif (!file_exists(self::PYTHON3_PATH)) {
                 $return['state'] = 'nok';
-                log::add('tvremote', 'debug', '[Python-Dep] Python venv executable not found at: ' . self::PYTHON3_PATH);
+                log::add(__CLASS__, 'debug', '[Python-Dep] Python venv executable not found at: ' . self::PYTHON3_PATH);
             } else {
                 $expectedCount = config::byKey('pythonDepNum', 'tvremote', 0, true);
                 $pythonDepString = config::byKey('pythonDepString', 'tvremote', '', true);
 
-                $cmd = system::getCmdSudo() . self::PYTHON3_PATH . ' -m pip freeze | grep -Ewci "' . $pythonDepString . '"';
+                $cmd = self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze | grep -Ewci "' . $pythonDepString . '"';
                 $foundCount = exec($cmd);
 
                 if ($foundCount < $expectedCount) {
                     $return['state'] = 'nok';
-                    log::add('tvremote', 'debug', '[Python-Dep] Missing Dependencies. Found: ' . $foundCount . ' / Expected: ' . $expectedCount);
-                    log::add('tvremote', 'debug', '[Python-Dep] Regex used: ' . $pythonDepString);
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Missing Dependencies. Found: ' . $foundCount . ' / Expected: ' . $expectedCount);
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Regex used: ' . $pythonDepString);
                     // Log actual pip freeze content for debugging
-                    $pipFreeze = shell_exec(system::getCmdSudo() . self::PYTHON3_PATH . ' -m pip freeze');
-                    log::add('tvremote', 'debug', '[Python-Dep] Pip Freeze Output: ' . str_replace(PHP_EOL, ' | ', trim($pipFreeze)));
+                    $pipFreeze = shell_exec(self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze');
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Pip Freeze Output: ' . str_replace(PHP_EOL, ' | ', trim($pipFreeze)));
                 } else {
                     $return['state'] = 'ok';
-                    log::add('tvremote', 'debug', '[Python-Dep] Dependencies installed. State : OK');
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Dependencies installed. State : OK');
                 }
             }
         }


### PR DESCRIPTION
Use __CLASS__ for log tags instead of hardcoded 'tvremote' to standardize logging. Remove sudo from pip commands and add --no-cache-dir to pip invocations when checking/installing dependencies. Switch pip freeze to use shell_exec and include its output in logs for easier debugging of missing Python packages.