### PR TITLE
Improve Python deps checks and logging

### DIFF
--- a/core/class/tvremote.class.php
+++ b/core/class/tvremote.class.php
@@ -77,27 +77,27 @@ class tvremote extends eqLogic {
         } else {
             if (exec(system::getCmdSudo() . system::get('cmd_check') . '-Ec "python3\-requests|python3\-setuptools|python3\-dev|python3\-venv"') < 4) {
                 $return['state'] = 'nok';
-                log::add('tvremote', 'debug', '[Python-Dep] System packages missing (python3-requests, python3-setuptools, python3-dev, or python3-venv)');
+                log::add(__CLASS__, 'debug', '[Python-Dep] System packages missing (python3-requests, python3-setuptools, python3-dev, or python3-venv)');
             } elseif (!file_exists(self::PYTHON3_PATH)) {
                 $return['state'] = 'nok';
-                log::add('tvremote', 'debug', '[Python-Dep] Python venv executable not found at: ' . self::PYTHON3_PATH);
+                log::add(__CLASS__, 'debug', '[Python-Dep] Python venv executable not found at: ' . self::PYTHON3_PATH);
             } else {
                 $expectedCount = config::byKey('pythonDepNum', 'tvremote', 0, true);
                 $pythonDepString = config::byKey('pythonDepString', 'tvremote', '', true);
 
-                $cmd = system::getCmdSudo() . self::PYTHON3_PATH . ' -m pip freeze | grep -Ewci "' . $pythonDepString . '"';
+                $cmd = self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze | grep -Ewci "' . $pythonDepString . '"';
                 $foundCount = exec($cmd);
 
                 if ($foundCount < $expectedCount) {
                     $return['state'] = 'nok';
-                    log::add('tvremote', 'debug', '[Python-Dep] Missing Dependencies. Found: ' . $foundCount . ' / Expected: ' . $expectedCount);
-                    log::add('tvremote', 'debug', '[Python-Dep] Regex used: ' . $pythonDepString);
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Missing Dependencies. Found: ' . $foundCount . ' / Expected: ' . $expectedCount);
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Regex used: ' . $pythonDepString);
                     // Log actual pip freeze content for debugging
-                    $pipFreeze = shell_exec(system::getCmdSudo() . self::PYTHON3_PATH . ' -m pip freeze');
-                    log::add('tvremote', 'debug', '[Python-Dep] Pip Freeze Output: ' . str_replace(PHP_EOL, ' | ', trim($pipFreeze)));
+                    $pipFreeze = shell_exec(self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze');
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Pip Freeze Output: ' . str_replace(PHP_EOL, ' | ', trim($pipFreeze)));
                 } else {
                     $return['state'] = 'ok';
-                    log::add('tvremote', 'debug', '[Python-Dep] Dependencies installed. State : OK');
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Dependencies installed. State : OK');
                 }
             }
         }


### PR DESCRIPTION
This pull request makes improvements to the dependency checking logic in the `tvremote` class, focusing on more consistent logging and better pip command usage. The most important changes are:

Dependency checking improvements:

* All logging calls in `dependancy_info()` now use `__CLASS__` instead of the hardcoded `'tvremote'`, ensuring correct class-based logging throughout the method.
* The pip commands used to check and list Python dependencies now include the `--no-cache-dir` option and no longer use `sudo`, which can improve reliability and security when running these commands.