### PR TITLE
v1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Plugin Configuration
+data/filters/*.json
+
 # IDE & Editors
 .vscode/*
 !.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
         "lastscan",
         "lasttime",
         "lastused",
+        "logfilters",
         "maxrss",
         "molotov",
         "mycanal",

--- a/core/ajax/tvremote.ajax.php
+++ b/core/ajax/tvremote.ajax.php
@@ -65,6 +65,16 @@ try {
         ajax::success(tvremote::sendBeginPairingAdb(init('mac'), init('host')));
     }
 
+    if (init('action') == 'saveLogFilters') {
+        $data = init('logFiltersData');
+        $filters = json_decode(is_string($data) ? $data : '[]', true);
+        if (!is_array($filters)) {
+            ajax::error(__('Format de données invalide', __FILE__));
+        }
+        tvremote::saveLogFilters($filters);
+        ajax::success();
+    }
+
     throw new Exception(__('Aucune méthode correspondante à', __FILE__) . ' : ' . init('action'));
     /*     * *********Catch exception*************** */
 } catch (Exception $e) {

--- a/core/class/tvremote.class.php
+++ b/core/class/tvremote.class.php
@@ -138,6 +138,7 @@ class tvremote extends eqLogic {
         $cmd = self::PYTHON3_PATH . " {$path}/tvremoted.py";
         $cmd .= ' --loglevel ' . log::convertLogLevel(log::getLogLevel(__CLASS__));
         $cmd .= ' --tvloglevel ' . config::byKey('tvLogLevel', __CLASS__, 'daemon');
+        $cmd .= ' --logfiltersenabled ' . (config::byKey('logFiltersEnabled', __CLASS__, '0') ? '1' : '0');
         $cmd .= ' --pluginversion ' . config::byKey('pluginVersion', __CLASS__, '0.0.0');
         $cmd .= ' --socketport ' . config::byKey('socketport', __CLASS__, '55112');
         $cmd .= ' --cyclefactor ' . config::byKey('cyclefactor', __CLASS__, '1.0');
@@ -556,6 +557,28 @@ class tvremote extends eqLogic {
                 'friendly_name' => $this->getConfiguration('friendly_name')
             );
             self::sendToDaemon($value_adb);
+        }
+    }
+
+    public static function createLogFiltersFile() {
+        $path = dirname(__FILE__) . '/../../data/filters/logfilters.json';
+        if (!file_exists($path)) {
+            file_put_contents($path, '[]');
+        }
+    }
+
+    public static function getLogFiltersFileContent() {
+        $path = dirname(__FILE__) . '/../../data/filters/logfilters.json';
+        if (!file_exists($path)) {
+            return array();
+        }
+        return json_decode(file_get_contents($path), true) ?: array();
+    }
+
+    public static function saveLogFilters($filters) {
+        $path = dirname(__FILE__) . '/../../data/filters/logfilters.json';
+        if (file_put_contents($path, json_encode($filters, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)) === false) {
+            throw new Exception(__('Impossible d\'enregistrer le fichier logfilters.json', __FILE__));
         }
     }
 

--- a/data/filters/README.md
+++ b/data/filters/README.md
@@ -1,0 +1,1 @@
+Log filters are stored here as `logfilters.json` (gitignored).

--- a/desktop/js/logfilters.tvremote.js
+++ b/desktop/js/logfilters.tvremote.js
@@ -137,7 +137,7 @@ window.initLogFilters = function(data) {
                     jeedomUtils.showAlert({ message: data.result, level: 'danger' })
                     return
                 }
-                jeedomUtils.showAlert({ message: '{{Filtres sauvegardés}}', level: 'success' })
+                jeedomUtils.showAlert({ message: '{{Filtres sauvegardés}} — {{Redémarrez le démon pour appliquer les changements}}', level: 'success' })
             }
         })
     })

--- a/desktop/js/logfilters.tvremote.js
+++ b/desktop/js/logfilters.tvremote.js
@@ -1,0 +1,146 @@
+/* This file is part of Jeedom.
+ *
+ * Jeedom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jeedom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(() => {
+'use strict'
+
+const AJAX_URL = 'plugins/tvremote/core/ajax/tvremote.ajax.php'
+const LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'DROP']
+
+function buildLevelSelect(selected) {
+    const select = document.createElement('select')
+    select.className = 'form-control lf-level'
+    LEVELS.forEach(function(l) {
+        const opt = document.createElement('option')
+        opt.value = l
+        opt.textContent = l === 'DROP' ? '---' : l
+        opt.selected = l === selected
+        select.appendChild(opt)
+    })
+    return select
+}
+
+function addRow(item) {
+    item = item || {}
+    const container = document.getElementById('logFiltersContainer')
+    if (!container) return
+    const enabled = item.enabled !== false
+    const level   = ((item.level || 'DEBUG') + '').toUpperCase()
+
+    const row = document.createElement('tr')
+    row.className = 'logFilterItem'
+
+    const tdCheck = document.createElement('td')
+    tdCheck.style.textAlign = 'center'
+    const cb = document.createElement('input')
+    cb.type = 'checkbox'
+    cb.className = 'lf-enabled'
+    cb.checked = enabled
+    tdCheck.appendChild(cb)
+
+    const tdPattern = document.createElement('td')
+    const input = document.createElement('input')
+    input.type = 'text'
+    input.className = 'form-control lf-pattern'
+    input.placeholder = '{{Ex: Cannot connect (device may be offline)}}'
+    input.value = item.pattern || ''
+    tdPattern.appendChild(input)
+
+    const tdLevel = document.createElement('td')
+    tdLevel.appendChild(buildLevelSelect(level))
+
+    const tdRemove = document.createElement('td')
+    tdRemove.style.textAlign = 'center'
+    const icon = document.createElement('i')
+    icon.className = 'fas fa-minus-circle lf-remove icon_red'
+    icon.style.cursor = 'pointer'
+    icon.title = '{{Supprimer}}'
+    tdRemove.appendChild(icon)
+
+    row.append(tdCheck, tdPattern, tdLevel, tdRemove)
+    container.appendChild(row)
+}
+
+function collectRows() {
+    const rows = document.querySelectorAll('.logFilterItem')
+    const result = []
+    rows.forEach(function(row) {
+        const pattern = row.querySelector('.lf-pattern').value.trim()
+        if (!pattern) return
+        result.push({
+            enabled: row.querySelector('.lf-enabled').checked,
+            pattern: pattern,
+            level:   row.querySelector('.lf-level').value
+        })
+    })
+    return result
+}
+
+window.initLogFilters = function(data) {
+    const dataArray = Array.isArray(data) ? data : []
+    dataArray.forEach(addRow)
+
+    const addBtn = document.getElementById('bt_addLogFilter')
+    if (addBtn) addBtn.addEventListener('click', function() { addRow({}) })
+
+    const container = document.getElementById('logFiltersContainer')
+    if (container) {
+        container.addEventListener('click', function(e) {
+            const btn = e.target.closest('.lf-remove')
+            if (btn) btn.closest('.logFilterItem').remove()
+        })
+    }
+
+    const selectAllBtn = document.getElementById('bt_selectAllLogFilters')
+    if (selectAllBtn) selectAllBtn.addEventListener('click', function() {
+        document.querySelectorAll('.lf-enabled').forEach(function(cb) { cb.checked = true })
+    })
+
+    const unselectAllBtn = document.getElementById('bt_unselectAllLogFilters')
+    if (unselectAllBtn) unselectAllBtn.addEventListener('click', function() {
+        document.querySelectorAll('.lf-enabled').forEach(function(cb) { cb.checked = false })
+    })
+
+    document.querySelectorAll('.tvremote-logfilter-suggest').forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault()
+            addRow({ pattern: link.dataset.pattern, level: link.dataset.level, enabled: true })
+        })
+    })
+
+    const saveBtn = document.getElementById('bt_saveLogFilters')
+    if (saveBtn) saveBtn.addEventListener('click', function() {
+        const filters = collectRows()
+        domUtils.ajax({
+            type: 'POST',
+            url: AJAX_URL,
+            data: { action: 'saveLogFilters', logFiltersData: JSON.stringify(filters) },
+            dataType: 'json',
+            error: function(request) {
+                jeedomUtils.showAlert({ message: (request.responseJSON && request.responseJSON.result) || '{{Erreur lors de la sauvegarde}}', level: 'danger' })
+            },
+            success: function(data) {
+                if (data.state !== 'ok') {
+                    jeedomUtils.showAlert({ message: data.result, level: 'danger' })
+                    return
+                }
+                jeedomUtils.showAlert({ message: '{{Filtres sauvegardés}}', level: 'success' })
+            }
+        })
+    })
+}
+
+})()

--- a/desktop/modal/logfilters.tvremote.php
+++ b/desktop/modal/logfilters.tvremote.php
@@ -1,0 +1,44 @@
+<?php
+if (!isConnect('admin')) {
+    throw new Exception('{{401 - Accès non autorisé}}');
+}
+$logFiltersData = tvremote::getLogFiltersFileContent();
+?>
+
+<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; flex-wrap:wrap; gap:8px;">
+    <span class="text-muted">
+        <i class="fas fa-info-circle"></i>
+        {{Définissez les patterns à intercepter et le niveau de log à appliquer. Cochez/décochez pour activer/désactiver une règle sans la perdre.}}
+    </span>
+    <a class="btn btn-success btn-sm" id="bt_saveLogFilters">
+        <i class="fas fa-save"></i> {{Sauvegarder}}
+    </a>
+</div>
+
+<div style="margin-bottom:10px; display:flex; gap:6px; flex-wrap:wrap;">
+    <a class="btn btn-sm btn-success" id="bt_addLogFilter"><i class="fas fa-plus"></i> {{Ajouter}}</a>
+    <a class="btn btn-sm btn-default" id="bt_selectAllLogFilters" title="{{Tout activer}}"><i class="fas fa-check-double"></i></a>
+    <a class="btn btn-sm btn-default" id="bt_unselectAllLogFilters" title="{{Tout désactiver}}"><i class="fas fa-minus-square"></i></a>
+</div>
+
+<table class="table table-bordered table-condensed" style="width:100%; table-layout:fixed;">
+    <thead>
+        <tr>
+            <th style="width:60px; text-align:center;">{{Actif}}</th>
+            <th>{{Pattern (sous-chaîne du message de log)}}</th>
+            <th style="width:180px;">{{Niveau cible}}</th>
+            <th style="width:40px;"></th>
+        </tr>
+    </thead>
+    <tbody id="logFiltersContainer"></tbody>
+</table>
+
+<div style="margin-top:8px; font-size:11px; color:var(--al-info-color)">
+    {{Suggestions :}}
+    <a href="#" class="tvremote-logfilter-suggest" data-pattern="Cannot connect (device may be offline)" data-level="DEBUG">Cannot connect (device may be offline) &rarr; DEBUG</a>
+</div>
+
+<?php include_file('desktop', 'logfilters.tvremote', 'js', 'tvremote'); ?>
+<script>
+    initLogFilters(<?= json_encode($logFiltersData) ?>);
+</script>

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -129,6 +129,20 @@ if (!isConnect()) {
                     </select>
                 </div>
             </div>
+            <div class="form-group">
+                <label class="col-lg-3 control-label">{{Activer les filtres de logs}}
+                    <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
+                    <sup><i class="fas fa-question-circle tooltips" title="{{Active la personnalisation des niveaux de log. Les filtres sont définis dans la fenêtre de gestion dédiée.}}"></i></sup>
+                </label>
+                <div class="col-lg-1">
+                    <input type="checkbox" class="configKey" data-l1key="logFiltersEnabled" />
+                </div>
+                <div class="col-lg-2">
+                    <a class="btn btn-primary customclass-openlogfilters">
+                        <i class="fas fa-filter"></i> {{Gérer les filtres}}
+                    </a>
+                </div>
+            </div>
         </div>
     </fieldset>
     <fieldset>
@@ -185,5 +199,17 @@ if (!isConnect()) {
   
   setupResetButton('.customclass-resettvcertkey', 'resetTVCertKey', '{{Reset TV Cert (OK)}}')
   setupResetButton('.customclass-resetadbkeys', 'resetAdbKeys', '{{Reset ADB Keys (OK)}}')
+
+  // Filtres de logs
+  document.querySelector('.customclass-openlogfilters')?.addEventListener('click', function() {
+    jeeDialog.dialog({
+      id: 'md_logFiltersTvremote',
+      title: '{{Filtres de logs}}',
+      contentUrl: 'index.php?v=d&plugin=tvremote&modal=logfilters.tvremote',
+      width: '65%',
+      height: '60%',
+      top: '18vh'
+    })
+  })
 })()
 </script>

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "tvremote",
 	"name": "TV Remote",
-	"pluginVersion": "1.3.21",
+	"pluginVersion": "1.4.0",
 	"description": {
 		"fr_FR": "Plugin pour contrôler les équipements Android de type Télévision (Sony, Nvidia Shield, Freebox TV, etc...) via le service de télécommande Google (TVRemote) ou via ADB. Il permet de contrôler les différentes fonctions de sa télévision (power, volume, entrées HDMI, lancement d'applications, chaînes TV, navigation dans l'interface, etc...)",
 		"en_US": "Plugin to control Android TV devices (Sony, Nvidia Shield, Freebox TV, etc...) via Google remote control service (TVRemote) or via ADB. It allows you to control various functions of your TV (power, volume, HDMI inputs, launching applications, TV channels, navigating the interface, etc...)",

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -55,6 +55,11 @@ function tvremote_install() {
     if (config::byKey('disableUpdateMsg', 'tvremote') == '') {
         config::save('disableUpdateMsg', '0', 'tvremote');
     }
+    if (config::byKey('logFiltersEnabled', 'tvremote') == '') {
+        config::save('logFiltersEnabled', '0', 'tvremote');
+    }
+
+    tvremote::createLogFiltersFile();
 
     $dependencyInfo = tvremote::dependancy_info();
     if (!isset($dependencyInfo['state'])) {
@@ -108,6 +113,11 @@ function tvremote_update() {
     if (config::byKey('disableUpdateMsg', 'tvremote') == '') {
         config::save('disableUpdateMsg', '0', 'tvremote');
     }
+    if (config::byKey('logFiltersEnabled', 'tvremote') == '') {
+        config::save('logFiltersEnabled', '0', 'tvremote');
+    }
+
+    tvremote::createLogFiltersFile();
 
     $dependencyInfo = tvremote::dependancy_info();
     if (!isset($dependencyInfo['state'])) {

--- a/resources/tvremoted/config.py
+++ b/resources/tvremoted/config.py
@@ -25,6 +25,10 @@ class Config(object):
         self.known_hosts = []  # Hosts for AndroidTVRemote2
         self.known_hosts_adb = []  # Hosts for ADB
         self.remote_mac = []  # MAC addresses for AndroidTVRemote2
+
+        self.log_filters_enabled: bool = False
+        self.log_filters: list = []  # [{ "pattern": str, "level": str, "enabled": bool }]
+        self.log_filters_file_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'data/filters/logfilters.json'))
         self.remote_mac_adb = []  # MAC addresses for ADB
         self.remote_names = []  # Names for AndroidTVRemote2
         self.remote_names_adb = []  # Names for ADB
@@ -125,6 +129,10 @@ class Config(object):
     @property
     def tv_log_level(self):
         return self._kwargs.get('tvloglevel', 'daemon')
+
+    @property
+    def log_filters_enabled_arg(self):
+        return self._kwargs.get('logfiltersenabled', '0')
 
     @property
     def api_key(self):

--- a/resources/tvremoted/tvremoted.py
+++ b/resources/tvremoted/tvremoted.py
@@ -1554,10 +1554,44 @@ class TVRemoted:
 
 # ----------------------------------------------------------------------------
 
+class PatternRemapFilter(logging.Filter):
+    """Remappe le niveau de log des records dont le message contient un pattern configuré."""
+
+    _LEVEL_MAP = {
+        'DEBUG':   logging.DEBUG,
+        'INFO':    logging.INFO,
+        'WARNING': logging.WARNING,
+        'ERROR':   logging.ERROR,
+    }
+
+    def __init__(self, entries: list) -> None:
+        super().__init__()
+        self._rules = [
+            (e['pattern'], e['level'].upper())
+            for e in entries
+            if e.get('enabled', True) and e.get('pattern', '').strip()
+        ]
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        for pattern, level in self._rules:
+            if pattern in msg:
+                if level == 'DROP':
+                    return False
+                target = self._LEVEL_MAP.get(level)
+                if target is not None:
+                    record.levelno = target
+                    record.levelname = level
+                return True
+        return True
+
+# ----------------------------------------------------------------------------
+
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='TVRemote Daemon for Jeedom plugin')
     parser.add_argument("--loglevel", help="Log Level for the daemon", type=str)
     parser.add_argument("--tvloglevel", help="Log Level for TV libraries (zeroconf, androidtvremote2, adb_shell)", type=str, default='daemon')
+    parser.add_argument("--logfiltersenabled", help="Enable log filters", type=str, default='0')
     parser.add_argument("--pluginversion", help="Plugin Version", type=str)
     parser.add_argument("--socketport", help="Port for TVRemote server", type=str)
     parser.add_argument("--cyclefactor", help="Cycle Factor", type=str)
@@ -1597,6 +1631,25 @@ if config.tv_log_level != 'daemon':
     logging.getLogger('zeroconf').setLevel(_tv_level)
     logging.getLogger('androidtvremote2').setLevel(_tv_level)
     logging.getLogger('adb_shell').setLevel(_tv_level)
+
+if config.log_filters_enabled_arg != '0':
+    config.log_filters_enabled = True
+
+if config.log_filters_enabled:
+    try:
+        with open(config.log_filters_file_path, 'r', encoding='utf-8') as _f:
+            config.log_filters = json.load(_f)
+    except FileNotFoundError:
+        logging.warning('[DAEMON][LOGFILTERS] Fichier introuvable : %s', config.log_filters_file_path)
+    except Exception as _e:
+        logging.warning('[DAEMON][LOGFILTERS] Erreur lecture filtres : %s', _e)
+
+if config.log_filters_enabled and config.log_filters:
+    _remap_filter = PatternRemapFilter(config.log_filters)
+    for _handler in logging.root.handlers:
+        _handler.addFilter(_remap_filter)
+    _active_count = sum(1 for r in config.log_filters if r.get('enabled', True))
+    logging.info('[DAEMON][LOGFILTERS] %d filtre(s) actif(s) sur %d', _active_count, len(config.log_filters))
 
 try:
     _LOGGER.info('[DAEMON] Starting Daemon')

--- a/resources/tvremoted/tvremoted.py
+++ b/resources/tvremoted/tvremoted.py
@@ -1657,6 +1657,7 @@ try:
     _LOGGER.info('[DAEMON] Pairing Name: %s', config.client_name)
     _LOGGER.info('[DAEMON] Log Level: %s', config.log_level)
     _LOGGER.info('[DAEMON] TV Log Level: %s', config.tv_log_level)
+    _LOGGER.info('[DAEMON] Log Filters Enabled: %s | rules: %d', config.log_filters_enabled, len(config.log_filters))
     _LOGGER.info('[DAEMON] Socket Port: %s', config.socket_port)
     _LOGGER.info('[DAEMON] Socket Host: %s', config.socket_host)
     _LOGGER.info('[DAEMON] Cycle Factor: %s', config.cycle_factor)


### PR DESCRIPTION
This pull request introduces a new feature for customizable log filtering in the TV Remote plugin, allowing users to define patterns and target log levels for specific log messages. The implementation includes both backend and frontend components, as well as configuration and persistence of filter rules. The main changes are grouped below:

**Log Filters Feature Implementation**

* Added support for user-defined log filters in the daemon: Users can specify patterns to match log messages and assign them a target log level or drop them entirely. This is handled in Python by the new `PatternRemapFilter` class and integrated into the daemon startup logic. (`resources/tvremoted/tvremoted.py` [[1]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3R1557-R1594) [[2]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3R1635-R1660); `resources/tvremoted/config.py` [[3]](diffhunk://#diff-8b4f659c2771e37c0782413436be78de41ca375e9fe7037275b564c1f53ade5fR28-R31) [[4]](diffhunk://#diff-8b4f659c2771e37c0782413436be78de41ca375e9fe7037275b564c1f53ade5fR133-R136)
* Added PHP methods for managing log filters, including file creation, reading, and saving, with persistence in `data/filters/logfilters.json`. (`core/class/tvremote.class.php` [core/class/tvremote.class.phpR563-R584](diffhunk://#diff-baae8b747340dcbf37887831f80949a6fa1798c82afbb49188e281d6b3590403R563-R584))
* Added a new AJAX action to save log filters from the frontend to the backend. (`core/ajax/tvremote.ajax.php` [core/ajax/tvremote.ajax.phpR68-R77](diffhunk://#diff-979d4f1d06009f1aec3a13c438d396071232d3b100d013fbaa9c494b442dde7fR68-R77))

**User Interface Enhancements**

* Introduced a modal dialog for managing log filters, accessible from the plugin configuration. Users can add, edit, enable/disable, or remove filters via a dedicated UI. (`desktop/modal/logfilters.tvremote.php` [[1]](diffhunk://#diff-36541ecdfc806bfd96c4449740ad7cbdbda291e0ca2a3389d6fb99767e8481a5R1-R44); `desktop/js/logfilters.tvremote.js` [[2]](diffhunk://#diff-5f40e8281ae273f50f6e95d28966f2f2493e57f8ebd265b975ad9b9a82ee6348R1-R146)
* Added a new configuration option in the plugin settings to enable/disable log filters and open the management modal. (`plugin_info/configuration.php` [[1]](diffhunk://#diff-e470ffcc8c2302f57a8564a3d59e3b1e107e468005929fdfbcfa41efd084931aR132-R145) [[2]](diffhunk://#diff-e470ffcc8c2302f57a8564a3d59e3b1e107e468005929fdfbcfa41efd084931aR202-R213)

**Configuration and Persistence**

* Ensured log filters are initialized and persisted across plugin install/update, and that the filters file is created if missing. (`plugin_info/install.php` [[1]](diffhunk://#diff-d29ad66623b8d1c93164e29ccae746ec492d78c2a5f7f10a2eb8b6ab450cb292R58-R62) [[2]](diffhunk://#diff-d29ad66623b8d1c93164e29ccae746ec492d78c2a5f7f10a2eb8b6ab450cb292R116-R120)
* Updated `.vscode/settings.json` and added documentation for the filters directory. (`.vscode/settings.json` [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R53); `data/filters/README.md` [[2]](diffhunk://#diff-20568221d0f4613ae63715a990eaf32d8df65d7b06b66eb965c558f5fd194887R1)

**Miscellaneous**

* Bumped the plugin version to `1.4.0` to reflect the new feature. (`plugin_info/info.json` [plugin_info/info.jsonL4-R4](diffhunk://#diff-73fca01855a04cfd1363d72519ecb7f9a94f7511bcf777ffdcb78c3eb26c1f85L4-R4))

These changes collectively provide a flexible mechanism for users to control log verbosity and filter unwanted log messages based on custom rules, improving the usability and maintainability of the plugin's logging system.