### PR TITLE
add whitespace for readability in config.py

### DIFF
--- a/resources/tvremoted/config.py
+++ b/resources/tvremoted/config.py
@@ -29,6 +29,7 @@ class Config(object):
         self.log_filters_enabled: bool = False
         self.log_filters: list = []  # [{ "pattern": str, "level": str, "enabled": bool }]
         self.log_filters_file_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'data/filters/logfilters.json'))
+
         self.remote_mac_adb = []  # MAC addresses for ADB
         self.remote_names = []  # Names for AndroidTVRemote2
         self.remote_names_adb = []  # Names for ADB


### PR DESCRIPTION
This pull request makes a minor change to the `resources/tvremoted/config.py` file, adding whitespace for readability in the `__init__` method. No functional changes were introduced.