### PR TITLE
v1.4.1

### DIFF
--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "tvremote",
 	"name": "TV Remote",
-	"pluginVersion": "1.4.0",
+	"pluginVersion": "1.4.1",
 	"description": {
 		"fr_FR": "Plugin pour contrôler les équipements Android de type Télévision (Sony, Nvidia Shield, Freebox TV, etc...) via le service de télécommande Google (TVRemote) ou via ADB. Il permet de contrôler les différentes fonctions de sa télévision (power, volume, entrées HDMI, lancement d'applications, chaînes TV, navigation dans l'interface, etc...)",
 		"en_US": "Plugin to control Android TV devices (Sony, Nvidia Shield, Freebox TV, etc...) via Google remote control service (TVRemote) or via ADB. It allows you to control various functions of your TV (power, volume, HDMI inputs, launching applications, TV channels, navigating the interface, etc...)",

--- a/resources/tvremoted/tvremoted.py
+++ b/resources/tvremoted/tvremoted.py
@@ -171,7 +171,7 @@ class EQRemote(object):
                 self._logger.debug(traceback.format_exc())
 
             def is_available_updated(is_available: bool) -> None:
-                self._logger.info("[EQRemote][Is_Available][%s] Notification :: %s", self._macAddr, is_available)
+                self._logger.debug("[EQRemote][Is_Available][%s] Notification :: %s", self._macAddr, is_available)
                 try:
                     # UpdateLastTime
                     currentTime = int(time.time())
@@ -193,7 +193,7 @@ class EQRemote(object):
                     self._logger.debug(traceback.format_exc())
 
             def is_on_updated(is_on: bool) -> None:
-                self._logger.info("[EQRemote][Is_On][%s] Notification :: %s", self._macAddr, is_on)
+                self._logger.debug("[EQRemote][Is_On][%s] Notification :: %s", self._macAddr, is_on)
                 try:
                     # UpdateLastTime
                     currentTime = int(time.time())
@@ -215,7 +215,7 @@ class EQRemote(object):
                     self._logger.debug(traceback.format_exc())
                 
             def current_app_updated(current_app: str) -> None:
-                self._logger.info("[EQRemote][Current_App][%s] Notification :: %s", self._macAddr, current_app)
+                self._logger.debug("[EQRemote][Current_App][%s] Notification :: %s", self._macAddr, current_app)
                 try:
                     # UpdateLastTime
                     currentTime = int(time.time())
@@ -236,7 +236,7 @@ class EQRemote(object):
                     self._logger.debug(traceback.format_exc())
 
             def volume_info_updated(volume_info: VolumeInfo) -> None:
-                self._logger.info("[EQRemote][Volume_Info][%s] Notification :: %s", self._macAddr, volume_info)
+                self._logger.debug("[EQRemote][Volume_Info][%s] Notification :: %s", self._macAddr, volume_info)
                 try:
                     # UpdateLastTime
                     currentTime = int(time.time())
@@ -690,7 +690,7 @@ class EQRemoteADB(object):
             
             # Connect on-demand if not already connected
             if not self._persistent_connection and not self._connected:
-                self._logger.info("[EQRemoteADB][SendCommand] On-demand mode: connecting...")
+                self._logger.debug("[EQRemoteADB][SendCommand] On-demand mode: connecting...")
                 if self._adb is None:
                     self._adb = AdbDeviceTcpAsync(self._host, self._port, default_transport_timeout_s=self._config.adb_timeout)
                 


### PR DESCRIPTION
This pull request makes minor changes focused on improving the logging behavior and updating the plugin version. The main update is to reduce the verbosity of the logs by changing several log messages from the `info` level to the `debug` level, which will help keep the logs cleaner in production environments.

Logging improvements:

* Changed log level from `info` to `debug` for state update notifications in `tvremoted.py`, including availability, power state, current app, and volume info updates. [[1]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L174-R174) [[2]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L196-R196) [[3]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L218-R218) [[4]](diffhunk://#diff-9e8ef8770dd1c222cc03478bef10c83dfe55075d9e17af0ec80179d440bc18a3L239-R239)
* Changed log level from `info` to `debug` for on-demand ADB connection messages in the `send_command` method of `tvremoted.py`.

Version update:

* Updated the plugin version from `1.4.0` to `1.4.1` in `info.json` to reflect these changes.