### PR TITLE
Limit CI workflows to relevant file changes

### DIFF
--- a/.github/workflows/checkPHP.yml
+++ b/.github/workflows/checkPHP.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - beta
+    paths:
+      - '**/*.php'
 
 jobs:
   php-lint:

--- a/.github/workflows/checkPHPCompat.yml
+++ b/.github/workflows/checkPHPCompat.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - beta
+    paths:
+      - '**/*.php'
 
 jobs:
   php-compat:

--- a/.github/workflows/checkPython.yml
+++ b/.github/workflows/checkPython.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - beta
+    paths:
+      - 'resources/**/*.py'
 
 jobs:
   python-check:


### PR DESCRIPTION
Add path filters to pull_request triggers so workflows only run for relevant files on the beta branch. checkPHP.yml and checkPHPCompat.yml now include '**/*.php', and checkPython.yml includes 'resources/**/*.py'. This reduces unnecessary CI runs and conserves resources by running language-specific checks only when corresponding files change.