### PR TITLE
Add workflow_dispatch to GitHub workflows

### DIFF
--- a/.github/workflows/checkPHP.yml
+++ b/.github/workflows/checkPHP.yml
@@ -6,6 +6,7 @@ on:
       - beta
     paths:
       - '**/*.php'
+  workflow_dispatch:
 
 jobs:
   php-lint:

--- a/.github/workflows/checkPHPCompat.yml
+++ b/.github/workflows/checkPHPCompat.yml
@@ -6,6 +6,7 @@ on:
       - beta
     paths:
       - '**/*.php'
+  workflow_dispatch:
 
 jobs:
   php-compat:

--- a/.github/workflows/checkPython.yml
+++ b/.github/workflows/checkPython.yml
@@ -6,6 +6,7 @@ on:
       - beta
     paths:
       - 'resources/**/*.py'
+  workflow_dispatch:
 
 jobs:
   python-check:

--- a/.github/workflows/js-check.yml
+++ b/.github/workflows/js-check.yml
@@ -6,6 +6,7 @@ on:
       - beta
     paths:
       - '**/*.js'
+  workflow_dispatch:
 
 jobs:
   js-lint:


### PR DESCRIPTION
Enable manual runs from the Actions UI by adding workflow_dispatch to the CI workflows. Updated .github/workflows/checkPHP.yml, checkPHPCompat.yml, checkPython.yml, and js-check.yml to include the manual dispatch trigger while preserving the existing branch/path filters.