### PR TITLE
Bump actions/setup-node to v5

### DIFF
--- a/.github/workflows/js-check.yml
+++ b/.github/workflows/js-check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 


### PR DESCRIPTION
Update the js-check workflow to use actions/setup-node@v5 (was @v4). This ensures the workflow uses the latest setup-node release, improving compatibility with Node.js 22 and picking up fixes and enhancements from the newer action version.